### PR TITLE
KMS integration for secret management

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,9 @@
   "main": "handler.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "offline": "sls offline"
+    "offline": "sls offline",
+    "encryptSecret": "ts-node src/scripts/encryptSecret.ts",
+    "decryptSecret": "ts-node src/scripts/decryptSecret.ts"
   },
   "dependencies": {
     "@nestjs/common": "^6.10.14",
@@ -27,6 +29,7 @@
     "@types/node": "^10.12.18",
     "@types/source-map-support": "^0.5.0",
     "@types/supertest": "^2.0.8",
+    "aws-sdk": "^2.606.0",
     "jest": "^24.9.0",
     "serverless": "^1.60.5",
     "serverless-offline": "^5.12.1",

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -1,0 +1,11 @@
+export interface Config {
+  cmsKeyId: string;
+  encryptedDataKey: string;
+}
+
+export const config: Config = {
+  cmsKeyId:
+    "arn:aws:kms:us-east-1:330560821579:key/12863ea7-0bfb-4014-8d36-1a2c39505bb6",
+  encryptedDataKey:
+    "AQIDAHjwrSMKicHwwIfFboo1WM76p+us0YuB0n2MIrqWcMZcfAH9LKJYf4us4rY70hZYpacAAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMC1H2Qayonah7nTYPAgEQgDuq4sHn5gzYCbfbtJMlDCBVNMYF35v9B0Uu5m2HN74SF6NAHXml6iAfHIiQk46Swtyt6HTMoWauyaCO9Q=="
+};

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -1,10 +1,10 @@
 export interface Config {
-  cmsKeyId: string;
+  cmkId: string;
   encryptedDataKey: string;
 }
 
 export const config: Config = {
-  cmsKeyId:
+  cmkId:
     "arn:aws:kms:us-east-1:330560821579:key/12863ea7-0bfb-4014-8d36-1a2c39505bb6",
   encryptedDataKey:
     "AQIDAHjwrSMKicHwwIfFboo1WM76p+us0YuB0n2MIrqWcMZcfAH9LKJYf4us4rY70hZYpacAAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMC1H2Qayonah7nTYPAgEQgDuq4sHn5gzYCbfbtJMlDCBVNMYF35v9B0Uu5m2HN74SF6NAHXml6iAfHIiQk46Swtyt6HTMoWauyaCO9Q=="

--- a/backend/src/scripts/decryptSecret.ts
+++ b/backend/src/scripts/decryptSecret.ts
@@ -1,0 +1,32 @@
+import * as AWS from "aws-sdk";
+
+import { config } from "../config/config";
+import { decryptSecret } from "../util/secrets";
+
+const toEncryptCLI = process.argv[2];
+if (!toEncryptCLI) {
+  console.error("Error: input parameter requred");
+  console.error("");
+  console.error("Usage: yarn -s decryptSecret encryptedSecret");
+  process.exit(1);
+}
+
+const kms = new AWS.KMS({
+  region: "us-east-1"
+});
+
+(async function(toDecrypt: string) {
+  const { encryptedDataKey } = config;
+  const decryptResponse = await kms
+    .decrypt({
+      CiphertextBlob: Buffer.from(encryptedDataKey, "base64")
+    })
+    .promise();
+
+  const decryptedSecret = decryptSecret(
+    toDecrypt,
+    decryptResponse.Plaintext as Buffer
+  );
+
+  console.log(decryptedSecret);
+})(toEncryptCLI);

--- a/backend/src/scripts/decryptSecret.ts
+++ b/backend/src/scripts/decryptSecret.ts
@@ -3,8 +3,8 @@ import * as AWS from "aws-sdk";
 import { config } from "../config/config";
 import { decryptSecret } from "../util/secrets";
 
-const toEncryptCLI = process.argv[2];
-if (!toEncryptCLI) {
+const toDecryptCLI = process.argv[2];
+if (!toDecryptCLI) {
   console.error("Error: input parameter requred");
   console.error("");
   console.error("Usage: yarn -s decryptSecret encryptedSecret");
@@ -29,4 +29,4 @@ const kms = new AWS.KMS({
   );
 
   console.log(decryptedSecret);
-})(toEncryptCLI);
+})(toDecryptCLI);

--- a/backend/src/scripts/encryptSecret.ts
+++ b/backend/src/scripts/encryptSecret.ts
@@ -1,0 +1,32 @@
+import * as AWS from "aws-sdk";
+
+import { config } from "../config/config";
+import { encryptSecret } from "../util/secrets";
+
+const toEncryptCLI = process.argv[2];
+if (!toEncryptCLI) {
+  console.error("Error: input parameter requred");
+  console.error("");
+  console.error("Usage: yarn -s encryptSecret secret");
+  process.exit(1);
+}
+
+const kms = new AWS.KMS({
+  region: "us-east-1"
+});
+
+(async function(toEncrypt: string) {
+  const { encryptedDataKey } = config;
+  const decryptResponse = await kms
+    .decrypt({
+      CiphertextBlob: Buffer.from(encryptedDataKey, "base64")
+    })
+    .promise();
+
+  const encryptedSecret = encryptSecret(
+    toEncrypt,
+    decryptResponse.Plaintext as Buffer
+  );
+
+  console.log(encryptedSecret);
+})(toEncryptCLI);

--- a/backend/src/util/secrets.ts
+++ b/backend/src/util/secrets.ts
@@ -1,0 +1,27 @@
+//  https://gist.github.com/vlucas/2bd40f62d20c1d49237a109d491974eb
+
+import * as crypto from "crypto";
+
+const IV_LENGTH = 16; // For AES, this is always 16
+
+export const encryptSecret = (text: string, ENCRYPTION_KEY: Buffer): string => {
+  let iv = crypto.randomBytes(IV_LENGTH);
+  let cipher = crypto.createCipheriv("aes-256-cbc", ENCRYPTION_KEY, iv);
+  let encrypted = cipher.update(text);
+
+  encrypted = Buffer.concat([encrypted, cipher.final()]);
+
+  return iv.toString("hex") + ":" + encrypted.toString("hex");
+};
+
+export const decryptSecret = (text: string, ENCRYPTION_KEY: Buffer): string => {
+  let textParts = text.split(":");
+  let iv = Buffer.from(textParts.shift(), "hex");
+  let encryptedText = Buffer.from(textParts.join(":"), "hex");
+  let decipher = crypto.createDecipheriv("aes-256-cbc", ENCRYPTION_KEY, iv);
+  let decrypted = decipher.update(encryptedText);
+
+  decrypted = Buffer.concat([decrypted, decipher.final()]);
+
+  return decrypted.toString();
+};

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -1863,6 +1863,21 @@ aws-sdk@^2.597.0:
     uuid "3.3.2"
     xml2js "0.4.19"
 
+aws-sdk@^2.606.0:
+  version "2.606.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.606.0.tgz#877ffad75f3ae8688a244f4efbb29ae7662295b9"
+  integrity sha512-PI4vabKfMdvACzefIpm4cL4Fwji+pQQlK1zPXtz9+JzdPCp5FcEhbpjJucfeMaOByrC2ThXXOdCf1rUhjSiYFg==
+  dependencies:
+    buffer "4.9.1"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 aws-serverless-express@^3.3.6:
   version "3.3.6"
   resolved "https://registry.yarnpkg.com/aws-serverless-express/-/aws-serverless-express-3.3.6.tgz#5fb35c23af3d6e18a6bebdb4397d20dfdcc0a828"

--- a/cloudformation/kms.yml
+++ b/cloudformation/kms.yml
@@ -1,0 +1,55 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Resources:
+  TableStakesKMSKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: Default KMS key for tablestakes
+      KeyPolicy:
+        Version: "2012-10-17"
+        Id: "key-default-1"
+        Statement:
+          -
+            Sid: "Enable IAM User Permissions"
+            Effect: "Allow"
+            Principal:
+              AWS: !Join ["", ["arn:aws:iam::", !Ref "AWS::AccountId", ":root"]]
+            Action: "kms:*"
+            Resource: "*"
+          -
+            Sid: "Allow administration of the key"
+            Effect: "Allow"
+            Principal:
+              AWS: !Join ["", ["arn:aws:iam::", !Ref "AWS::AccountId", ":user/rhussmann"]]
+            Action:
+              - "kms:Create*"
+              - "kms:Describe*"
+              - "kms:Enable*"
+              - "kms:List*"
+              - "kms:Put*"
+              - "kms:Update*"
+              - "kms:Revoke*"
+              - "kms:Disable*"
+              - "kms:Get*"
+              - "kms:Delete*"
+              - "kms:ScheduleKeyDeletion"
+              - "kms:CancelKeyDeletion"
+            Resource: "*"
+          -
+            Sid: "Allow use of the key"
+            Effect: "Allow"
+            Principal:
+              AWS: !Join ["", ["arn:aws:iam::", !Ref "AWS::AccountId", ":user/rhussmann"]]
+            Action:
+              - "kms:DescribeKey"
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey"
+              - "kms:GenerateDataKeyWithoutPlaintext"
+            Resource: "*"
+      KeyUsage: ENCRYPT_DECRYPT
+      PendingWindowInDays: 7
+      Tags:
+      - Key: Name
+        Value: Default key

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -2,9 +2,9 @@
 
 table-stakes uses AWS KMS to manage secrets.
 
-A customer-managed secret (CMS) is generated using CloudFormation. Once the key is generated, a data-encryption key can be generated. AWS generates both a plaintext (unencrypted) and ciphertext (encrypted) version of the key. The encrypted version of the data-encryption key is stored in the application configuration.
+A Customer Master Key ([CMK](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master_keys)) is generated using CloudFormation. Once the key is generated, a [data-encryption key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#data-keys) can be generated. AWS generates both a plaintext (unencrypted) and ciphertext (encrypted) version of the key. The encrypted version of the data-encryption key is stored in the application configuration.
 
-Before storing and managing any secrets, the CMS must be generated within AWS. This key is stored in AWS and is never pulled into the application. The CMS is used only to generate and decrypt the data-dencryption key. Once the CMS is created, you won't need to interact with it.
+Before storing and managing any secrets, the CMK must be generated within AWS. This key is stored in AWS and is never pulled into the application. The CMK is used only to generate and decrypt the data-dencryption key. Once the CMK is created, you won't need to interact with it.
 
 The data-encryption key is the primary key used within the application. It's used to encrypt and decrypt secrets in the application.
 
@@ -12,9 +12,9 @@ table-stakes uses AES-256 encryption.
 
 ## Prerequisites
 
-### Generate the CMS
+### Generate the CMK
 
-The CMS is generated with a CloudFormation template in the `/cloudformation/kms.yml` file. To generate the CMS, from the root directory:
+The CMK is generated with a CloudFormation template in the `/cloudformation/kms.yml` file. To generate the CMK, from the root directory:
 
 * `aws cloudformation create-stack --stack-name kms --template-body file://cloudformation/kms.yml`
 
@@ -24,7 +24,7 @@ You can check the AWS CloudFormation console to check on the status of the key g
 
 To generate the data-encryption key:
 
-* `aws kms generate-data-key --key-spec AES_256 --key-id <ARN or CMS key ID>`
+* `aws kms generate-data-key --key-spec AES_256 --key-id <ARN or CMK key ID>`
 
 This command will return both the plaintext base64-encoded key (this is theunencrypted key), and the Ciphertext base64-encoded encrypted key.
 
@@ -36,7 +36,7 @@ The ciphertext, however, has been encrypted and is safe to commit to the repo.
 
 ### Updating the application configuration
 
-Update the value for `encryptedDataKey` in `src/config/config.ts` to the ciphertext value. Also, update the `cmsKeyId` value in the same value to the ARN returned from generating the data-encryption key.
+Update the value for `encryptedDataKey` in `src/config/config.ts` to the ciphertext value. Also, update the `cmkId` value in the same value to the ARN returned from generating the data-encryption key.
 
 ## Encrypting Secrets
 
@@ -69,3 +69,7 @@ $ ts-node src/scripts/decryptSecret.ts 0966971d2214e8f63a74c2747379b1fa:8c2562ba
 shhhhhhhhh
 Done in 4.74s.
 ```
+
+## Reference
+
+* [AWS KMS Service Concepts](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html)

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,71 @@
+# Secrets
+
+table-stakes uses AWS KMS to manage secrets.
+
+A customer-managed secret (CMS) is generated using CloudFormation. Once the key is generated, a data-encryption key can be generated. AWS generates both a plaintext (unencrypted) and ciphertext (encrypted) version of the key. The encrypted version of the data-encryption key is stored in the application configuration.
+
+Before storing and managing any secrets, the CMS must be generated within AWS. This key is stored in AWS and is never pulled into the application. The CMS is used only to generate and decrypt the data-dencryption key. Once the CMS is created, you won't need to interact with it.
+
+The data-encryption key is the primary key used within the application. It's used to encrypt and decrypt secrets in the application.
+
+table-stakes uses AES-256 encryption.
+
+## Prerequisites
+
+### Generate the CMS
+
+The CMS is generated with a CloudFormation template in the `/cloudformation/kms.yml` file. To generate the CMS, from the root directory:
+
+* `aws cloudformation create-stack --stack-name kms --template-body file://cloudformation/kms.yml`
+
+You can check the AWS CloudFormation console to check on the status of the key generation. Once this is compete you can generate a data-encryption key.
+
+### Generate the data-encryption key
+
+To generate the data-encryption key:
+
+* `aws kms generate-data-key --key-spec AES_256 --key-id <ARN or CMS key ID>`
+
+This command will return both the plaintext base64-encoded key (this is theunencrypted key), and the Ciphertext base64-encoded encrypted key.
+
+**IMPORTANT**
+
+The plaintext value returned is a master key for the application. DO NOT COOMMIT THIS KEY TO SOURCE CONTROL OR A PUBLIC PLACE.
+
+The ciphertext, however, has been encrypted and is safe to commit to the repo.
+
+### Updating the application configuration
+
+Update the value for `encryptedDataKey` in `src/config/config.ts` to the ciphertext value. Also, update the `cmsKeyId` value in the same value to the ARN returned from generating the data-encryption key.
+
+## Encrypting Secrets
+
+table-stakes provides yarn scripts for encrypting secrets (passwords, API keys), such that these encrypted values can be included in config files and decrypted at runtime. There's also a decryption script for one-off decryption and sanity checking.
+
+### Manually encrypting a secret
+
+Use the process below to encrypt a secret value (such as an external API key). This encrypted value can then safely be stored in a config.
+
+For the example, I'm going to encrypt the string "shhhhhhhhh".
+
+```
+╭─rhussmann at rhgalago in ~/Code/table-stakes/backend
+╰─± yarn encryptSecret shhhhhhhhh
+yarn run v1.21.1
+$ ts-node src/scripts/encryptSecret.ts shhhhhhhhh
+0966971d2214e8f63a74c2747379b1fa:8c2562ba755152e79104952e99a9ee0f
+Done in 4.65s.
+```
+
+### Manually decrypting a secret
+
+To decrypt a secret, use the `decryptSecret` yarn script. For the example, I'll be using the secret value generated above.
+
+```
+╭─rhussmann at rhgalago in ~/Code/table-stakes/backend
+╰─± yarn decryptSecret 0966971d2214e8f63a74c2747379b1fa:8c2562ba755152e79104952e99a9ee0f
+yarn run v1.21.1
+$ ts-node src/scripts/decryptSecret.ts 0966971d2214e8f63a74c2747379b1fa:8c2562ba755152e79104952e99a9ee0f
+shhhhhhhhh
+Done in 4.74s.
+```


### PR DESCRIPTION
Provides CloudFormation template for generating a [Customer Master Key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master_keys), as well as documentation on creating a derived [data-encryption key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#data-keys).

Added documentation on running the template as well as creating a data-encryption key.

This PR a encrypted data-encryption key derived from the CMK generated from the Cloudformation template. This data-encryption key can be used at run-time to decrypt secrets (like API keys) that were encrypted out-of-band.

This pull-request also includes scripts for encrypting and decrypting secrets out-of-band using a yarn script.

In general, when a new secret is necessary (for instance, an API key), the yarn script `encryptSecret` can be used from the command-line to encrypt the secret. The resulting encrypted secret can then safely be stored in the application configuration and committed directly to source control. At run-time, the application will decrypt data-encryption key and use that to decrypt the secret. This allow for safely adding encrypted secrets directly to the source-code.