### PR TITLE
Add a sample endpoint authenticated with JWT

### DIFF
--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Post, Request, UseGuards } from "@nestjs/common";
 import { AuthGuard } from "@nestjs/passport";
 import { AuthService } from "./auth.service";
-import { ApiBody } from "@nestjs/swagger";
+import { ApiBody, ApiBearerAuth } from "@nestjs/swagger";
 
 @Controller()
 export class AppController {
@@ -34,5 +34,12 @@ export class AppController {
   @Post("auth/login")
   async login(@Request() req: any) {
     return this.authService.login(req.user);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard("jwt"))
+  @Get("profile")
+  getProfile(@Request() req: any) {
+    return req.user;
   }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,15 +5,16 @@ import { UsersService } from "./users.service";
 import { LocalStrategy } from "./local.strategy";
 import { JwtModule } from "@nestjs/jwt";
 import { jwtConstants } from "./constants";
+import { JwtStrategy } from "./jwt.strategy";
 
 @Module({
   imports: [
     JwtModule.register({
       secret: jwtConstants.secret,
-      signOptions: { expiresIn: "60s" }
+      signOptions: { expiresIn: "1d" }
     })
   ],
   controllers: [AppController],
-  providers: [AuthService, UsersService, LocalStrategy]
+  providers: [AuthService, UsersService, LocalStrategy, JwtStrategy]
 })
 export class AppModule {}

--- a/backend/src/jwt.strategy.ts
+++ b/backend/src/jwt.strategy.ts
@@ -1,0 +1,19 @@
+import { ExtractJwt, Strategy } from "passport-jwt";
+import { PassportStrategy } from "@nestjs/passport";
+import { Injectable } from "@nestjs/common";
+import { jwtConstants } from "./constants";
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor() {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: jwtConstants.secret
+    });
+  }
+
+  async validate(payload: any) {
+    return { userId: payload.sub, username: payload.username };
+  }
+}

--- a/backend/src/lambda.ts
+++ b/backend/src/lambda.ts
@@ -37,6 +37,7 @@ async function bootstrapServer(): Promise<Server> {
       .setTitle("Table-stakes API")
       .setDescription("The table-stakes API description")
       .setVersion("1.0")
+      .addBearerAuth()
       .addServer("http://localhost:3000/", "Localhost")
       .addServer(
         "https://rpdd6m4hh4.execute-api.us-east-1.amazonaws.com/dev/",

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -11,9 +11,15 @@ import { AppModule } from "./app.module";
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const options = new DocumentBuilder()
-    .setTitle("Table-stakes example")
+    .setTitle("Table-stakes API")
     .setDescription("The table-stakes API description")
     .setVersion("1.0")
+    .addBearerAuth()
+    .addServer("http://localhost:3000/", "Localhost")
+    .addServer(
+      "https://rpdd6m4hh4.execute-api.us-east-1.amazonaws.com/dev/",
+      "The deployed server"
+    )
     .build();
 
   const document = SwaggerModule.createDocument(app, options);


### PR DESCRIPTION
* `/profile` endpoint
* Uses bearer token authentication
* Added Swagger support
* Extend JWT lifetime to 1 day