### PR TITLE
Add occasion detail endpoint

### DIFF
--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,7 +1,20 @@
-import { Controller, Get, Post, Request, UseGuards } from "@nestjs/common";
+import {
+  Controller,
+  Get,
+  Param,
+  Post,
+  Request,
+  UseGuards
+} from "@nestjs/common";
 import { AuthGuard } from "@nestjs/passport";
 import { AuthService } from "./auth.service";
 import { ApiBody, ApiBearerAuth } from "@nestjs/swagger";
+
+interface Occasion {
+  id: string;
+  name: string;
+  date: string;
+}
 
 @Controller()
 export class AppController {
@@ -48,5 +61,16 @@ export class AppController {
   @Get("occasions")
   async getOccasions() {
     return Promise.resolve([]);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard("jwt"))
+  @Get("occasions/:id")
+  getOccasion(@Param("id") id: string): Occasion {
+    return {
+      id,
+      name: "The event",
+      date: new Date().toISOString()
+    };
   }
 }


### PR DESCRIPTION
* Available at `/occasions/{occasion_id}`

Currently returns an Occasion structure:
```
{
  "id": string,
  "name": string,
  "date": string
}
```
where `id` is the URL parameter passed in, `name` is hardcoded to `"the event"`, and `time` is an ISO string representing the current time.